### PR TITLE
add Gaussian prior as another option in BARTBQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Project Documentation: https://bart-bq.readthedocs.io/en/latest/
     dbarts
     matrixStats
     mvtnorm
+    msm
 ```
 
 ## To run the genz integrals approximations:
@@ -48,7 +49,7 @@ Project Documentation: https://bart-bq.readthedocs.io/en/latest/
 1) Install all the necessary packages
 
 ```
-install.packages(c("yaml", "MASS", "cubature", "lhs", "data.tree", "matrixStats", "mvtnorm", "doParallel", "kernlab"))
+install.packages(c("yaml", "MASS", "cubature", "lhs", "data.tree", "matrixStats", "mvtnorm", "doParallel", "kernlab", "msm"))
 ```
 and also 
 ```
@@ -58,7 +59,7 @@ install.packages(packageurl, repos=NULL, type="source")
 
 2) To simulate, run the test scripts with customized inputs. There are 6 inputs in total; the last input is optional and only works for the step function (`genz_function_number` = 7). For example:
 ```
-Rscript integrationMain.R dimension num_iterations genz_function_number sequential_flag kernel_name (number_of_jumps_for_step_function)
+Rscript integrationMain.R dimension num_iterations genz_function_number kernel_name sequential_flag (number_of_jumps_for_step_function)
 
 ```
 where `genz_function_number` is following the indexing in https://www.sfu.ca/~ssurjano/integration.html. 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ packageurl <- "https://cran.r-project.org/src/contrib/Archive/dbarts/dbarts_0.9-
 install.packages(packageurl, repos=NULL, type="source")
 ```
 
-2) To simulate, run the test scripts with customized inputs. There are 6 inputs in total; the last input is optional and only works for the step function (_genz_function_number_ = 7). For example:
+2) To simulate, run the test scripts with customized inputs. There are 6 inputs in total; the last input is optional and only works for the step function (`genz_function_number` = 7). For example:
 ```
 Rscript integrationMain.R dimension num_iterations genz_function_number sequential_flag kernel_name (number_of_jumps_for_step_function)
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ install.packages(packageurl, repos=NULL, type="source")
 
 2) To simulate, run the test scripts with customized inputs. There are 6 inputs in total; the last input is optional and only works for the step function (`genz_function_number` = 7). For example:
 ```
-Rscript integrationMain.R dimension num_iterations genz_function_number kernel_name sequential_flag (number_of_jumps_for_step_function)
+Rscript integrationMain.R dimension num_iterations genz_function_number kernel_name sequential_flag (measure) (number_of_jumps_for_step_function)
 
 ```
 where `genz_function_number` is following the indexing in https://www.sfu.ca/~ssurjano/integration.html. 

--- a/integrationMain.R
+++ b/integrationMain.R
@@ -72,7 +72,11 @@ if (whichGenz == 8) { genz <- mix; genzFunctionName <-  deparse(substitute(mix))
 print("Testing with: %s" %--% genzFunctionName)
 
 # prepare training dataset
-trainX <- replicate(dim, runif(100))
+if (measure == "uniform") {
+  trainX <- replicate(dim, runif(100))
+} else if (measure == "gaussian") {
+  trainX <- replicate(dim, rtnorm(100, mean = 0.5, lower=0, upper=1))
+}
 trainY <- genz(trainX)
 
 # Bayesian Quadrature method

--- a/integrationMain.R
+++ b/integrationMain.R
@@ -23,22 +23,34 @@ args <- commandArgs(TRUE)
 dim <- as.double(args[1])
 num_iterations <- as.double(args[2])
 whichGenz <- as.double(args[3])
-whichKernel <- as.character(args[5])
+whichKernel <- as.character(args[4])
 # turn on/off sequential design
 # 1 denotes TRUE to sequential
 # 0 denotes FALSE to sequential
 cat("\nBegin testing:\n")
-if (as.double(args[4]) == 1 | is.na(as.double(args[4]))) {
+if (as.double(args[5]) == 1 | is.na(as.double(args[5]))) {
   sequential <- TRUE
 } else {
   sequential <- FALSE
 }
 cat("Sequantial design set to", sequential, "\n")
+# prior measure over the inputs
+# uniform by default
+if (as.character(args[6]) != "gaussian" | is.na(args[6])) {
+  measure <- "uniform"
+} else{
+  measure <- as.character(args[6])
+}
+cat("Prior measure:", measure, "\n")
 # extra parameter for step function
 # 1 by default
-jumps <- as.double(args[6])
-if (whichGenz == 7 & is.na(jumps)) { jumps <- 1 }
-cat("Number of jumps for step function:", jumps, "\n")
+if (whichGenz == 7 & is.na(args[7])) {
+  jumps <- 1
+  cat("Number of jumps for step function:", jumps, "\n")
+} else if (whichGenz == 7){
+  jumps <- as.double(args[7])
+  cat("Number of jumps for step function:", jumps, "\n")
+}
 
 if (num_iterations == 1) { stop("NEED MORE THAN 1 ITERATION") }
 
@@ -67,7 +79,7 @@ trainY <- genz(trainX)
 # set number of new query points using sequential design
 source("src/BARTBQ.R")
 t0 <- proc.time()
-predictionBART <- mainBARTBQ(dim, num_iterations, FUN = genz, trainX, trainY, sequential)
+predictionBART <- mainBARTBQ(dim, num_iterations, FUN = genz, trainX, trainY, sequential, measure)
 t1 <- proc.time()
 bartTime <- (t1 - t0)[[1]]
 
@@ -129,19 +141,30 @@ results <- data.frame(
 )
 
 if (!sequential){
-  csvName <- "results/genz/%s/results%sdim%sNoSequential.csv" %--% c(
+  csvName <- "results/genz/%s/%sDim%sNoSequential%s.csv" %--% c(
           whichGenz, 
-          whichGenz, 
-          dim
-     )
-  figName <- "Figures/%s/%s%sDimNoSequential.pdf" %--% c(whichGenz, genzFunctionName, dim)
+          genzFunctionName,
+          dim,
+          tools::toTitleCase(measure)
+          )
+  figName <- "Figures/%s/%sDim%sNoSequential%s.pdf" %--% c(
+          whichGenz,
+          genzFunctionName,
+          dim,
+          tools::toTitleCase(measure)
+          )
 } else {
-  csvName <- "results/genz/%s/results%sdim%s.csv" %--% c(
+  csvName <- "results/genz/%s/%sDim%s%s.csv" %--% c(
           whichGenz, 
-          whichGenz, 
-          dim
+          genzFunctionName,
+          dim,
+          tools::toTitleCase(measure)
      )
-  figName <- "Figures/%s/%s%sDim.pdf" %--% c(whichGenz, genzFunctionName, dim)
+  figName <- "Figures/%s/%sDim%s%s.pdf" %--% c(
+          whichGenz,
+          genzFunctionName,
+          dim,
+          tools::toTitleCase(measure))
 }
 
 write.csv(results, file = csvName, row.names=FALSE)

--- a/temporary_gaussian_prior.R
+++ b/temporary_gaussian_prior.R
@@ -1,0 +1,127 @@
+# !/usr/bin/env R
+# Load required packages
+library(MASS)
+library(cubature)
+library(lhs)
+library(data.tree)
+library(dbarts)
+library(matrixStats)
+library(mvtnorm)
+library(doParallel)
+library(kernlab)
+
+# define string formatting
+`%--%` <- function(x, y) 
+# from stack exchange:
+# https://stackoverflow.com/questions/46085274/is-there-a-string-formatting-operator-in-r-similar-to-pythons
+{
+  do.call(sprintf, c(list(x), y))
+}
+
+# global parameters: dimension
+args <- commandArgs(TRUE)
+dim <- as.double(args[1])
+num_iterations <- as.double(args[2])
+whichGenz <- as.double(args[3])
+whichKernel <- as.character(args[4])
+# turn on/off sequential design
+# 1 denotes TRUE to sequential
+# 0 denotes FALSE to sequential
+cat("\nBegin testing:\n")
+if (as.double(args[5]) == 1 | is.na(as.double(args[5]))) {
+  sequential <- TRUE
+} else {
+  sequential <- FALSE
+}
+cat("Sequantial design set to", sequential, "\n")
+# prior measure over the inputs
+# uniform by default
+if (as.character(args[6]) != "gaussian" | is.na(args[6])) {
+  measure <- "uniform"
+} else{
+  measure <- as.character(args[6])
+}
+cat("Prior measure:", measure, "\n")
+# extra parameter for step function
+# 1 by default
+if (whichGenz == 7 & is.na(args[7])) {
+  jumps <- 1
+  cat("Number of jumps for step function:", jumps, "\n")
+} else if (whichGenz == 7){
+  jumps <- as.double(args[7])
+  cat("Number of jumps for step function:", jumps, "\n")
+}
+
+if (num_iterations == 1) { stop("NEED MORE THAN 1 ITERATION") }
+
+print(c(dim, num_iterations, whichGenz))
+source("src/genz/genz.R") # genz function to test
+
+if (whichGenz < 1 | whichGenz > 8) { stop("undefined genz function. Change 3rd argument to 1-8") }
+if (whichGenz == 3 & dim == 1) { stop("incorrect dimension. Discrete Genz function only defined for dimension >= 2") } 
+
+if (whichGenz == 1) { genz <- cont; genzFunctionName <-  deparse(substitute(cont)) }
+if (whichGenz == 2) { genz <- copeak; genzFunctionName <-  deparse(substitute(copeak)) }
+if (whichGenz == 3) { genz <- disc; genzFunctionName <-  deparse(substitute(disc)) }
+if (whichGenz == 4) { genz <- gaussian; genzFunctionName <-  deparse(substitute(gaussian)) }
+if (whichGenz == 5) { genz <- oscil; genzFunctionName <-  deparse(substitute(oscil)) }
+if (whichGenz == 6) { genz <- prpeak; genzFunctionName <-  deparse(substitute(prpeak)) }
+if (whichGenz == 7) { genz <- function(xx){return(step(xx, jumps=jumps))}; genzFunctionName <-  deparse(substitute(step)) }
+if (whichGenz == 8) { genz <- mix; genzFunctionName <-  deparse(substitute(mix)) }
+
+print("Testing with: %s" %--% genzFunctionName)
+
+# prepare training dataset
+if (measure == "uniform") {
+  trainX <- replicate(dim, runif(100))
+} else if (measure == "gaussian") {
+  trainX <- replicate(dim, rtnorm(100, mean = 0.5, lower=0, upper=1, dim^2/100))
+}
+trainY <- genz(trainX)
+
+# Bayesian Quadrature method
+# set number of new query points using sequential design
+source("src/BARTBQ.R")
+t0 <- proc.time()
+predictionBART <- mainBARTBQ(dim, num_iterations, FUN = genz, trainX, trainY, sequential, measure)
+t1 <- proc.time()
+bartTime <- (t1 - t0)[[1]]
+
+measure2 <- "gaussian"
+trainX <- replicate(dim, rtnorm(100, mean = 0.5, lower=0, upper=1))
+trainY <- genz(trainX)
+predictionBART2 <- mainBARTBQ(dim, num_iterations, FUN = genz, trainX, trainY, sequential, measure2)
+
+# Bayesian Quadrature with Monte Carlo integration method
+print("Begin Monte Carlo Integration")
+source("src/monteCarloIntegration.R")
+
+t0 <- proc.time()
+predictionMonteCarlo <- monteCarloIntegrationUniform(FUN = genz, numSamples=num_iterations, dim)
+t1 <- proc.time()
+
+MITime <- (t1 - t0)[[1]]
+
+print("Begin Plots")
+figName <- "Figures/GaussianUniformPriors%sDim%s%s.pdf" %--% c(
+          genzFunctionName,
+          dim,
+          tools::toTitleCase(measure)
+          )
+
+# 1. Open jpeg file
+pdf(figName, width = 10, height = 11)
+
+# 2. Create the plot
+par(mfrow = c(1,1), pty = "s")
+plot(predictionMonteCarlo$meanValueMonteCarlo, ylim = c(0, 0.1), main = genzFunctionName)
+points(predictionBART$meanValueBART, col = "red")
+points(predictionBART2$meanValueBART, col = "blue")
+legend("topright", legend = c("MC", "BART uniform", "BART Gaussian"), col = c("black", "red", "blue"), cex=0.8, lty = c(1,1,1))
+
+# 3. Close the file
+invisible(dev.off())
+
+print("Please check {ROOT}/%s for plots" %--% figName)
+
+

--- a/test_step_func.R
+++ b/test_step_func.R
@@ -36,13 +36,13 @@ dim <- as.double(args[1])
 num_iterations <- as.double(args[2])
 jumps <- 2
 whichGenz <- 7
-whichKernel <- as.character(args[4])
+whichKernel <- as.character(args[3])
 
 # turn on/off sequential design
 # 1 denotes TRUE to sequential
 # 0 denotes FALSE to sequential
 cat("\nBegin testing:\n")
-if (as.double(args[3]) == 1 | is.na(as.double(args[3]))) {
+if (as.double(args[4]) == 1 | is.na(as.double(args[4]))) {
   sequential <- TRUE
   print("Sequantial design set to TRUE.")
 } else {


### PR DESCRIPTION
### New code allows us to assume a Gaussian measure over the inputs in BARTBQ (previously uniform; see section 3.2 of our paper). 

To run, note the change in the format of the command-line argument:
`
Rscript integrationMain.R dimension num_iterations genz_function_number kernel_name sequential_flag (measure) (number_of_jumps_for_step_function)
`
`measure` is optional, and must be `gaussian` or `uniform` (default choice if not given).

To reproduce a fine-tuned version of Gaussian prior on the Gaussian peak integrand family:
`
Rscript temporary_gaussian_uniform_priors.R 1 300 4 rbf 1 gaussian
`
(And we need to **delete** `temporary_gaussian_uniform_priors.R` after we're happy with the modifications to `integrationMain.R`)

### Added new library `msm` for drawing samples from truncated Gaussian.
This needs to be downloaded in order to run `integrationMain.

### Changed the format of the names of the output figure and csv